### PR TITLE
Include opencv headers in the image

### DIFF
--- a/stage2/01-sys-tweaks/01-run.sh
+++ b/stage2/01-sys-tweaks/01-run.sh
@@ -109,6 +109,7 @@ cat extfiles/wpiutil-include.tar.gz | sh -c "cd ${ROOTFS_DIR}/usr/local/frc/incl
 cat extfiles/cscore-include.tar.gz | sh -c "cd ${ROOTFS_DIR}/usr/local/frc/include/ && tar xzf -"
 cat extfiles/ntcore-include.tar.gz | sh -c "cd ${ROOTFS_DIR}/usr/local/frc/include/ && tar xzf -"
 cat extfiles/cameraserver-include.tar.gz | sh -c "cd ${ROOTFS_DIR}/usr/local/frc/include/ && tar xzf -"
+cat extfiles/opencv-include.tar.gz | sh -c "cd ${ROOTFS_DIR}/usr/local/frc/include/ && tar xzf -"
 
 install -v -d "${ROOTFS_DIR}/usr/local/frc/share/OpenCV"
 


### PR DESCRIPTION
They were built, but not extracted to the actual filesystem.

Fixes #37.