### PR TITLE
Fix the C++ example

### DIFF
--- a/deps/examples/cpp-multiCameraServer/Makefile
+++ b/deps/examples/cpp-multiCameraServer/Makefile
@@ -12,7 +12,7 @@ clean:
 	rm ${EXE} *.o
 
 ${EXE}: main.o
-	${CXX} -o $@ $< -L/usr/local/frc/lib -lcameraserver -lcscore -lntcore -lwpiutil
+	${CXX} -pthread -o $@ $< -L/usr/local/frc/lib -lcameraserver -lcscore -lntcore -lwpiutil
 
 .cpp.o:
-	${CXX} -O -c -o $@ -I/usr/local/frc/include $<
+	${CXX} -pthread -O -c -o $@ -I/usr/local/frc/include $<

--- a/deps/examples/cpp-multiCameraServer/main.cpp
+++ b/deps/examples/cpp-multiCameraServer/main.cpp
@@ -47,11 +47,7 @@
    }
  */
 
-#ifdef __RASPBIAN__
 static const char* configFile = "/boot/frc.json";
-#else
-static const char* configFile = "frc.json";
-#endif
 
 namespace {
 
@@ -216,7 +212,7 @@ int main(int argc, char* argv[]) {
       });
        */
       runner.RunForever();
-    });
+    }).detach();
   }
 
   // loop forever


### PR DESCRIPTION
- Build with -pthread
- Detach the thread to avoid std::thread exception
- Remove `__RASPBIAN__` check (it's not defined by the on-Pi compiler)

Fixes #35.