### PR TITLE
Reboot at end of one-time filesystem resize

### DIFF
--- a/stage2/01-sys-tweaks/files/resize2fs_once
+++ b/stage2/01-sys-tweaks/files/resize2fs_once
@@ -17,7 +17,8 @@ case "$1" in
     update-rc.d resize2fs_once remove &&
     rm /etc/init.d/resize2fs_once &&
     sed -i '/vfat\|ext4/s/defaults/defaults,ro/' /etc/fstab &&
-    log_end_msg $?
+    log_end_msg $? &&
+    reboot
     ;;
   *)
     echo "Usage: $0 start" >&2


### PR DESCRIPTION
This results in the first "real" boot being read-only instead of half
writable (/boot read-only but / writable).

Fixes #36.