### PR TITLE
Install published pynetworktables wheel from PyPI

### DIFF
--- a/stage3/01-sys-tweaks/01-run.sh
+++ b/stage3/01-sys-tweaks/01-run.sh
@@ -44,8 +44,8 @@ wget -nc -nv -O allwpilib.tar.gz \
     https://github.com/wpilibsuite/allwpilib/archive/05d6660a6be0d37064a9fab44232b8379884ccab.tar.gz
 
 # pynetworktables
-wget -nc -nv -O pynetworktables.tar.gz \
-    https://github.com/robotpy/pynetworktables/archive/8a4288452be26e26dccad32980f46000e8d97928.tar.gz
+wget -nc -nv -O pynetworktables.whl \
+    https://files.pythonhosted.org/packages/source/p/pynetworktables/pynetworktables-2019.0.0-py3-none-any.whl
 
 # robotpy-cscore
 wget -nc -nv -O robotpy-cscore.tar.gz \
@@ -76,11 +76,6 @@ popd
 # allwpilib
 tar xzf "${DOWNLOAD_DIR}/allwpilib.tar.gz"
 mv allwpilib-* allwpilib
-
-# pynetworktables
-tar xzf "${DOWNLOAD_DIR}/pynetworktables.tar.gz"
-mv pynetworktables-* pynetworktables
-echo "__version__ = '2019.0.1'" > pynetworktables/ntcore/version.py
 
 # robotpy-cscore
 tar xzf "${DOWNLOAD_DIR}/robotpy-cscore.tar.gz"
@@ -282,12 +277,7 @@ popd
 
 #sh -c "cd ${EXTRACT_DIR}/pynetworktables && tar cf - networktables ntcore" | sh -c "cd ${ROOTFS_DIR}/usr/local/lib/python3.5/dist-packages/ && tar xf -"
 on_chroot << EOF
-pip3 install setuptools
-pushd /usr/src/pynetworktables
-python3 setup.py build
-python3 setup.py install
-python3 setup.py clean
-popd
+pip3 install /usr/src/pynetworktables.whl
 EOF
 
 #


### PR DESCRIPTION
Avoids having to create a (potentially incorrect) version.py manually.

Uses pip to install to generate and install the *.pyc (bytecode) files.