### PR TITLE
Python example: Use UTF-8 encoding when opening frc.json

### DIFF
--- a/deps/examples/python-multiCameraServer/multiCameraServer.py
+++ b/deps/examples/python-multiCameraServer/multiCameraServer.py
@@ -91,7 +91,7 @@ def readConfig():
 
     # parse file
     try:
-        with open(configFile, "rt") as f:
+        with open(configFile, "rt", encoding="utf-8") as f:
             j = json.load(f)
     except OSError as err:
         print("could not open '{}': {}".format(configFile, err), file=sys.stderr)


### PR DESCRIPTION
Fixes #99.