### PR TITLE
Simplify OpenCV cmake flags

### DIFF
--- a/stage3/01-sys-tweaks/01-run.sh
+++ b/stage3/01-sys-tweaks/01-run.sh
@@ -128,28 +128,10 @@ build_opencv () {
     mkdir -p $1
     pushd $1
     cmake "${EXTRACT_DIR}/opencv-3.4.4" \
-        -DWITH_CUDA=OFF \
-        -DWITH_IPP=OFF \
-        -DWITH_ITT=OFF \
-        -DWITH_OPENCL=OFF \
-        -DWITH_FFMPEG=OFF \
-        -DWITH_OPENEXR=OFF \
-        -DWITH_GSTREAMER=OFF \
-        -DWITH_LAPACK=ON \
-        -DWITH_GTK=ON \
-        -DWITH_1394=OFF \
-        -DWITH_JASPER=OFF \
-        -DWITH_TIFF=OFF \
         -DBUILD_JPEG=ON \
-        -DBUILD_PNG=ON \
-        -DBUILD_ZLIB=ON \
         -DBUILD_TESTS=OFF \
         -DPython_ADDITIONAL_VERSIONS=3.5 \
-        -DWITH_WEBP=OFF \
         -DBUILD_JAVA=$3 \
-        -DBUILD_WITH_STATIC_CRT=OFF \
-        -DWITH_PROTOBUF=OFF \
-        -DWITH_DIRECTX=OFF \
         -DENABLE_CXX11=ON \
         -DBUILD_SHARED_LIBS=$3 \
         -DCMAKE_BUILD_TYPE=$2 \


### PR DESCRIPTION
Now that we're building in a more standard way it's not necessary to
manually override these.  The only override kept is to build jpeg (as
we are tweaking it to not output JPEG decompression errors).