### PR TITLE
Fix various places where username is hardcoded

### DIFF
--- a/deps/tools/configServer/Makefile
+++ b/deps/tools/configServer/Makefile
@@ -36,7 +36,7 @@ configServer: ${OBJS}
 	${CXX} -g -O -Wall -c -o $@ \
 	    ${CXXFLAGS} \
 	    ${DEPS_CFLAGS} \
-	    '-DEXEC_HOME="/home${FIRST_USER_NAME}"' \
+	    '-DEXEC_HOME="/home/${FIRST_USER_NAME}"' \
 	    '-DFRC_JSON="${FRC_JSON}"' \
 	    '-DDHCPCD_CONF="${DHCPCD_CONF}"' \
 	    '-DAPP_UID=${APP_UID}' \

--- a/deps/tools/configServer/Makefile
+++ b/deps/tools/configServer/Makefile
@@ -1,6 +1,7 @@
 IMG_VERSION?=$(shell git describe)
 DEPS_CFLAGS?=$(shell pkg-config --cflags cscore wpiutil)
 DEPS_LIBS?=$(shell pkg-config --libs --static cscore wpiutil)
+EXEC_HOME?=/home/${FIRST_USER_NAME}
 FRC_JSON?=/boot/frc.json
 DHCPCD_CONF?=/boot/dhcpcd.conf
 APP_UID?=1000
@@ -36,7 +37,7 @@ configServer: ${OBJS}
 	${CXX} -g -O -Wall -c -o $@ \
 	    ${CXXFLAGS} \
 	    ${DEPS_CFLAGS} \
-	    '-DEXEC_HOME="/home/${FIRST_USER_NAME}"' \
+	    '-DEXEC_HOME="${EXEC_HOME}"' \
 	    '-DFRC_JSON="${FRC_JSON}"' \
 	    '-DDHCPCD_CONF="${DHCPCD_CONF}"' \
 	    '-DAPP_UID=${APP_UID}' \

--- a/deps/tools/configServer/Makefile
+++ b/deps/tools/configServer/Makefile
@@ -1,7 +1,6 @@
 IMG_VERSION?=$(shell git describe)
 DEPS_CFLAGS?=$(shell pkg-config --cflags cscore wpiutil)
 DEPS_LIBS?=$(shell pkg-config --libs --static cscore wpiutil)
-EXEC_HOME?=/home/pi
 FRC_JSON?=/boot/frc.json
 DHCPCD_CONF?=/boot/dhcpcd.conf
 APP_UID?=1000
@@ -37,7 +36,7 @@ configServer: ${OBJS}
 	${CXX} -g -O -Wall -c -o $@ \
 	    ${CXXFLAGS} \
 	    ${DEPS_CFLAGS} \
-	    '-DEXEC_HOME="${EXEC_HOME}"' \
+	    '-DEXEC_HOME="/home${FIRST_USER_NAME}"' \
 	    '-DFRC_JSON="${FRC_JSON}"' \
 	    '-DDHCPCD_CONF="${DHCPCD_CONF}"' \
 	    '-DAPP_UID=${APP_UID}' \

--- a/export-image/04-finalise/01-run.sh
+++ b/export-image/04-finalise/01-run.sh
@@ -5,15 +5,15 @@ INFO_FILE="${STAGE_WORK_DIR}/${IMG_FILENAME}.info"
 EXAMPLE_DIR="${STAGE_WORK_DIR}/examples"
 
 mkdir -p "${EXAMPLE_DIR}"
-cp -p "${ROOTFS_DIR}"/home/pi/zips/* "${EXAMPLE_DIR}/"
+cp -p "${ROOTFS_DIR}"/home/${FIRST_USER_NAME}/zips/* "${EXAMPLE_DIR}/"
 
 on_chroot << EOF
 /etc/init.d/fake-hwclock stop
 hardlink -t /usr/share/doc
 EOF
 
-if [ -d "${ROOTFS_DIR}/home/pi/.config" ]; then
-	chmod 700 "${ROOTFS_DIR}/home/pi/.config"
+if [ -d "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config" ]; then
+	chmod 700 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/.config"
 fi
 
 rm -f "${ROOTFS_DIR}/etc/apt/apt.conf.d/51cache"

--- a/stage4/01-sys-tweaks/01-run.sh
+++ b/stage4/01-sys-tweaks/01-run.sh
@@ -58,11 +58,11 @@ popd
 export PKG_CONFIG_LIBDIR=${ROOTFS_DIR}/usr/lib/arm-linux-gnueabihf/pkgconfig:${ROOTFS_DIR}/usr/lib/pkgconfig:${ROOTFS_DIR}/usr/share/pkgconfig:${ROOTFS_DIR}/usr/local/frc/lib/pkgconfig
 
 sh -c "cd ${BASE_DIR}/deps && tar cf - examples" | \
-    sh -c "cd ${ROOTFS_DIR}/home/pi && tar xf -"
-for dir in ${ROOTFS_DIR}/home/pi/examples/*; do
+    sh -c "cd ${ROOTFS_DIR}/home/${FIRST_USER_NAME} && tar xf -"
+for dir in ${ROOTFS_DIR}/home/${FIRST_USER_NAME}/examples/*; do
     cp "${BASE_DIR}/LICENSE.txt" "${dir}/"
 done
-chown -R 1000:1000 "${ROOTFS_DIR}/home/pi/examples"
+chown -R 1000:1000 "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/examples"
 
 rm -rf "${STAGE_WORK_DIR}/examples"
 sh -c "cd ${BASE_DIR}/deps && tar cf - examples" | \
@@ -105,8 +105,8 @@ zip -r cpp-multiCameraServer.zip cpp-multiCameraServer
 zip -r python-multiCameraServer.zip python-multiCameraServer
 
 # install zips
-install -v -o 1000 -g 1000 -d "${ROOTFS_DIR}/home/pi/zips/"
-install -v -o 1000 -g 1000 *.zip "${ROOTFS_DIR}/home/pi/zips/"
+install -v -o 1000 -g 1000 -d "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/zips/"
+install -v -o 1000 -g 1000 *.zip "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/zips/"
 
 popd
 
@@ -137,7 +137,7 @@ EOF
 #
 # Set up pi user scripts
 #
-install -m 755 -o 1000 -g 1000 files/runCamera "${ROOTFS_DIR}/home/pi/"
-install -m 755 -o 1000 -g 1000 files/runInteractive "${ROOTFS_DIR}/home/pi/"
-install -m 755 -o 1000 -g 1000 files/runService "${ROOTFS_DIR}/home/pi/"
+install -m 755 -o 1000 -g 1000 files/runCamera "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/"
+install -m 755 -o 1000 -g 1000 files/runInteractive "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/"
+install -m 755 -o 1000 -g 1000 files/runService "${ROOTFS_DIR}/home/${FIRST_USER_NAME}/"
 


### PR DESCRIPTION
If one changes FIRST_USER_NAME in the config file to something other than pi, stage 4 will fail due to the hardcoding of the pi username. This PR changes the hardcoded pi username to reference the FIRST_USER_NAME variable. I have tested that this works in my own independent image. I am not sure if FIRST_USER_NAME is set to pi if it is unset in the config, if not that will have to be added.