### PR TITLE
Refer to OpenCV jar dependency by proper name

### DIFF
--- a/deps/examples/java-multiCameraServer/build.gradle
+++ b/deps/examples/java-multiCameraServer/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile name: 'ntcore'
     compile name: 'cscore'
     compile name: 'cameraserver'
-    compile name: 'opencv-344'
+    compile name: 'opencv-347'
     compile name: 'wpilibj'
     compile name: 'wpiHal'
 }


### PR DESCRIPTION
Latest release has updated OpenCV to 347 but did not change build.gradle to match jar name appropriately.

Fixes (#131)